### PR TITLE
Hotfix/#7-Team column 수정

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,6 +62,7 @@ model User {
   accounts        Account[]
   sessions        Session[]
   habits          Habit[]
+  teams           Team[]
   teamMembers     TeamMember[]
   teamMessages    TeamMessage[]
   userPoints      UserPoint[]
@@ -105,6 +106,8 @@ model Team {
   emblem        String
   maxTeamSize   Int       @default(2)
   isOpened      Boolean   @default(false)
+  ownerId       String
+  user          User      @relation(fields: [ownerId], references: [id], onDelete: Cascade)
   teamMembers   TeamMember[]
   teamMessages  TeamMessage[]
 }


### PR DESCRIPTION
## 📢 개요
- Team 테이블에 생성자 id 관련 column 누락된 문제 발생
- Team 테이블 => `ownerId` column 생성
- Team과 User 테이블을 연결

## 🚩관련 이슈
- Hotfix: #7

## ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] CSS 스타일링
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 경로 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정 등)

### 🤔 리뷰 예상 시간 : `1`분
## ❗ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] Prisma => Team 테이블에 ownerId 추가
- [ ] Prisma => Team과 User 테이블 연결