### PR TITLE
Feat/#14 rank teams 페이지 구현

### DIFF
--- a/src/app/(main-contents)/rank/teams/TeamRankContent.tsx
+++ b/src/app/(main-contents)/rank/teams/TeamRankContent.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { TeamCard } from '@/components/team/TeamRankCard';
+import { useTeamQuery } from '@/lib/queries/useTeamQuery';
+
+// 팀 랭킹 UI
+export const TeamRankContent = () => {
+  const { data: teams, isPending, isError } = useTeamQuery(); // 데이터 가져오기
+  if (isPending) return <div>Loading...</div>;
+  if (isError) return <div>Error...</div>;
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-3xl font-bold mb-6">팀 랭킹</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {teams.map((team) => (
+          <TeamCard key={team.id} team={team} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/app/(main-contents)/rank/teams/page.tsx
+++ b/src/app/(main-contents)/rank/teams/page.tsx
@@ -1,4 +1,4 @@
-import { TeamRankContent } from './TeamRankContent';
+import { TeamRankContent } from './team-rank-content';
 
 // ISR
 export const revalidate = 60; // 추후 시간 설정 필요

--- a/src/app/(main-contents)/rank/teams/page.tsx
+++ b/src/app/(main-contents)/rank/teams/page.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import { TeamRankContent } from './TeamRankContent';
 
-const TeamRankPage = () => {
-  return <div>TeamRankPage</div>;
-};
+// ISR
+export const revalidate = 60; // 추후 시간 설정 필요
 
-export default TeamRankPage;
+export default function TeamRankPage() {
+  return <TeamRankContent />; // 클라이언트 컴포넌트 렌더링
+}

--- a/src/app/(main-contents)/rank/teams/team-rank-content.tsx
+++ b/src/app/(main-contents)/rank/teams/team-rank-content.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { TeamCard } from '@/components/team/TeamRankCard';
+import { useTeamQuery } from '@/lib/queries/useTeamQuery';
+
+// 팀 랭킹 UI
+export const TeamRankContent = () => {
+  const { data: teams, isPending, isError } = useTeamQuery(); // 데이터 가져오기
+  if (isPending) return <div>Loading...</div>;
+  if (isError) return <div>Error...</div>;
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-3xl font-bold mb-6">팀 랭킹</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {teams.map((team) => (
+          <TeamCard key={team.id} team={team} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/team/TeamRankCard.tsx
+++ b/src/components/team/TeamRankCard.tsx
@@ -1,0 +1,17 @@
+import { TeamData } from '@/types/teams';
+
+// 한 팀의 정보를 카드 형태로 보여주는 컴포넌트임당
+export const TeamCard = ({ team }: { team: TeamData }) => {
+  return (
+    <div className="border rounded-lg p-4 w-80 shadow-md">
+      <img
+        src={team.emblem}
+        alt={`${team.teamName} 엠블럼`}
+        className="w-16 h-16 mb-2"
+      />
+      <h2 className="text-xl font-bold">{team.teamName}</h2>
+      <p className="text-gray-600">{team.teamBio}</p>
+      <p className="text-sm mt-2">최대 인원: {team.maxTeamSize}명</p>
+    </div>
+  );
+};

--- a/src/lib/queries/useTeamQuery.ts
+++ b/src/lib/queries/useTeamQuery.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { fetchTeams } from '../services/teamServices';
+import { fetchGetTeams } from '../services/team.services';
 import { TeamData } from '@/types/teams';
 
 // 팀 데이터 가져오기 훅
@@ -7,7 +7,7 @@ export const useTeamQuery = () => {
   return useQuery<TeamData[]>({
     // TeamData 배열 반환
     queryKey: ['teams'],
-    queryFn: fetchTeams, // fetchTeams 호출 데이터 가져오기
+    queryFn: fetchGetTeams, // fetchTeams 호출 데이터 가져오기
   });
   // {data, isPending, isError} 같은 정보 반환
 };

--- a/src/lib/queries/useTeamQuery.ts
+++ b/src/lib/queries/useTeamQuery.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchTeams } from '../services/teamServices';
+import { TeamData } from '@/types/teams';
+
+// 팀 데이터 가져오기 훅
+export const useTeamQuery = () => {
+  return useQuery<TeamData[]>({
+    // TeamData 배열 반환
+    queryKey: ['teams'],
+    queryFn: fetchTeams, // fetchTeams 호출 데이터 가져오기
+  });
+  // {data, isPending, isError} 같은 정보 반환
+};

--- a/src/lib/services/teamServices.ts
+++ b/src/lib/services/teamServices.ts
@@ -1,0 +1,15 @@
+import { TeamData } from '@/types/teams';
+
+// 팀 데이터 가져오기
+export const fetchTeams = async (): Promise<TeamData[]> => {
+  const res = await fetch('/api/teams', {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  if (!res.ok) {
+    throw new Error('팀 데이터를 가져오는데 실패했습니다.');
+  }
+  return res.json();
+};

--- a/src/types/teams.ts
+++ b/src/types/teams.ts
@@ -1,4 +1,4 @@
-type TeamData = {
+export type TeamData = {
   id: string;
   teamName: string;
   teamBio: string;


### PR DESCRIPTION
<!---- PR 제목 예시 : Feat/#00-HomePage 기능 구현 -->

## 📢 개요
- 팀 랭킹 페이지를 만들어서 팀 목록을 카드 형태로 출력.
-  ISR로 설정한 시간에 맞게 갱신
- 처음에 `'use client'`와 `revalidate`를 같이 써서 오류가 났는데, 서버와 클라이언트를 분리해서 문제를 해결했습니다.
![image](https://github.com/user-attachments/assets/cb6681cd-9771-48b7-b1ed-8be7221c8af9)


## 🚩관련 이슈
#14 

## ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] CSS 스타일링
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 경로 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정 등)

### 🤔 리뷰 예상 시간 : `5`분
## ❗ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl  + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
